### PR TITLE
Store the Docker Compose configuration in this project

### DIFF
--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -1,0 +1,30 @@
+---
+version: "3.2"
+
+secrets:
+  aws_config:
+    file: secrets/aws_config
+  scraper_config:
+    file: secrets/scraper.json
+
+services:
+  update:
+    command:
+      - "--from=code@cyber.dhs.gov"
+      - "--to=webpublishing@hq.dhs.gov"
+      - "--cc=ncats-dev@beta.dhs.gov"
+      - "--reply=ncats-dev@beta.dhs.gov"
+      - "--json=code.json"
+      - "--subject=\"Latest code.gov JSON file\""
+      - "--text=body.txt"
+      - "--html=body.html"
+      - "--log-level=info"
+    environment:
+      - AWS_CONFIG_FILE=/run/secrets/aws_config
+      - AWS_PROFILE=default
+    image: dhsncats/code-gov-update:0.0.2
+    secrets:
+      - source: aws_config
+        target: aws_config
+      - source: scraper_config
+        target: scraper_config.json

--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -10,15 +10,15 @@ secrets:
 services:
   update:
     command:
-      - "--from=code@cyber.dhs.gov"
-      - "--to=webpublishing@hq.dhs.gov"
       - "--cc=ncats-dev@beta.dhs.gov"
-      - "--reply=ncats-dev@beta.dhs.gov"
+      - "--from=code@cyber.dhs.gov"
+      - "--html=body.html"
       - "--json=code.json"
+      - "--log-level=info"
+      - "--reply=ncats-dev@beta.dhs.gov"
       - "--subject=\"Latest code.gov JSON file\""
       - "--text=body.txt"
-      - "--html=body.html"
-      - "--log-level=info"
+      - "--to=webpublishing@hq.dhs.gov"
     environment:
       - AWS_CONFIG_FILE=/run/secrets/aws_config
       - AWS_PROFILE=default

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,8 +22,11 @@ def test_packages(host, directory):
     assert oct(host.file(directory["path"]).mode) == directory["mode"]
 
 
-@pytest.mark.parametrize("f", ["/var/cyhy/code-gov-update/docker-compose.yml"])
-def test_command(host, f):
+@pytest.mark.parametrize(
+    "file", [{"path": "/var/cyhy/code-gov-update/docker-compose.yml", "mode": "0o644"}]
+)
+def test_command(host, file):
     """Test that appropriate files exist."""
-    assert host.file(f).exists
-    assert host.file(f).is_file
+    assert host.file(file["path"]).exists
+    assert host.file(file["path"]).is_file
+    assert oct(host.file(file["path"]).mode) == file["mode"]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,8 @@
     path: /var/cyhy/code-gov-update
     state: directory
 
-- name: Download and untar the code-gov-update tarball
-  ansible.builtin.unarchive:
+- name: Install the Docker Compose configuration
+  ansible.builtin.copy:
     dest: /var/cyhy/code-gov-update
-    extra_opts:
-      - "--strip-components=1"
-    remote_src: yes
-    src: https://api.github.com/repos/cisagov/code-gov-update/tarball/develop
+    mode: 0644
+    src: docker-compose.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes this Ansible role to use a specific `docker-compose.yml` file configured in this repository instead of relying on the [`docker-compose.yml`](https://github.com/cisagov/code-gov-update/blob/8a53bc292057da9156b3bbb3aa082da140542c07/docker-compose.yml) and [`docker-compose.override.yml`](https://github.com/cisagov/code-gov-update/blob/8a53bc292057da9156b3bbb3aa082da140542c07/docker-compose.override.yml) files currently stored in [cisagov/code-gov-update].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The use of this role is to deploy the [cisagov/code-gov-update] image with a specific Docker Compose configuration. It makes more sense to make the Compose configuration independent of the Docker image's configuration. This means that the image can change significantly without impacting this role or it's deployment until it is updated to use a newer image tag.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/code-gov-update]: https://github.com/cisagov/code-gov-update