### PR TITLE
Update the Docker image used in the Docker Compose configuration

### DIFF
--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - AWS_CONFIG_FILE=/run/secrets/aws_config
       - AWS_PROFILE=default
-    image: dhsncats/code-gov-update:0.0.2
+    image: cisagov/code-gov-update:0.1.0
     secrets:
       - source: aws_config
         target: aws_config


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the source image from [dhsncats/code-gov-update] to [cisagov/code-gov-update] as well as changing the image tag from `0.0.2` to `0.1.0`.

### ⚠ Note ###

This pull request should not be merged until we have merged all the Terraform configuration changes in [cisagov/cyhy_amis] that are currently in testing.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This updates the Docker Compose configuration stored in this repository to align with the changes in https://github.com/cisagov/code-gov-update/pull/41.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified the Docker image functions in testing and with https://github.com/cisagov/cyhy_amis/pull/559 merged the UID is correct for freshly built and deployed instances.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[dhsncats/code-gov-update]: https://hub.docker.com/r/dhsncats/code-gov-update
[cisagov/code-gov-update]: https://hub.docker.com/r/cisagov/code-gov-update
[cisagov/cyhy_amis]: https://github.com/cisagov/cyhy_amis